### PR TITLE
Add import for OutputPhantomsPanel to prevent AttributeError

### DIFF
--- a/main/debugger_interface.py
+++ b/main/debugger_interface.py
@@ -23,6 +23,7 @@ from .components.callstack_panel import CallStackPanel
 from .components.console_panel import ConsolePanel
 from .components.variables_panel import VariablesPanel
 from .components.pages_panel import TabbedPanel
+from .components.panel import OutputPhantomsPanel
 
 from .repl import run_repl_command
 


### PR DESCRIPTION
Upon cloning, the extension doesn't work because it complains about DebuggerInterface not having panel.
This can be fixed by adding the appropiate import.

```
An exception occured in the main_loop
Traceback (most recent call last):
  File "C:\Users\martijndeboer\AppData\Roaming\Sublime Text 3\Packages\sublime_db\core\core.py", line 31, in _exception_handler
    raise context['exception']
  File "C:\Users\martijndeboer\AppData\Roaming\Sublime Text 3\Packages\sublime_db\libs\asyncio\events.py", line 127, in _run
    self._callback(*self._args)
  File "C:\Users\martijndeboer\AppData\Roaming\Sublime Text 3\Packages\sublime_db\main\commands\debugger.py", line 35, in run_main
    main.show()
  File "C:\Users\martijndeboer\AppData\Roaming\Sublime Text 3\Packages\sublime_db\main\debugger_interface.py", line 358, in show
    self.debugger_panel.show()
AttributeError: 'DebuggerInterface' object has no attribute 'panel'
```