### PR TITLE
Fixed naming issue

### DIFF
--- a/Commands/Commands.sublime-commands
+++ b/Commands/Commands.sublime-commands
@@ -3,7 +3,7 @@
 		"caption": "Preferences: Debugger Settings",
 		"command": "edit_settings",
 		"args": {
-		  "base_file": "${packages}/debugger/debugger.sublime-settings"
+		  "base_file": "${packages}/Debugger/debugger.sublime-settings"
 		}
 	},
 	{

--- a/Commands/Main.sublime-menu
+++ b/Commands/Main.sublime-menu
@@ -13,7 +13,7 @@
 			"caption": "Settings",
 				"command": "edit_settings",
 				"args": {
-				  "base_file": "${packages}/debugger/debugger.sublime-settings"
+				  "base_file": "${packages}/Debugger/debugger.sublime-settings"
 				}
 			},
 			{ "caption": "-"},


### PR DESCRIPTION
The default settings file path was wrong, because Package Control installs the package as "Debugger" and not as "debugger".