### PR TITLE
nodejs debug adapter

### DIFF
--- a/debug_adapters/nodejs.json
+++ b/debug_adapters/nodejs.json
@@ -1,0 +1,11 @@
+{
+    "command": [
+        "node",
+        "${package}/data/debug_adapters/vscode-node-debug2/extension/out/src/nodeDebug.js"
+    ],
+    "installation": {
+        "name": "vscode-node-debug2",
+        "url": "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-vscode/vsextensions/node-debug2/latest/vspackage",
+        "format": "zip"
+    }
+}

--- a/debugger.sublime-settings
+++ b/debugger.sublime-settings
@@ -45,6 +45,7 @@
 		"python" : "${package}/debug_adapters/python.json",
 		"go" : "${package}/debug_adapters/go.json",
 		"php" : "${package}/debug_adapters/php.json",
+		"nodejs" : "${package}/debug_adapters/nodejs.json",
 	}
 }
 


### PR DESCRIPTION
I've added configuration files for vscode-node-debug2 adapter.

Debug settings looks like this:

```json
	"debug.configurations":
	[
		{
			"request": "launch", 
			"name": "nodejs", 
			"type": "nodejs",
			"program": "${workspaceFolder}/hello_world/index.js"
		},
	]
```