### PR TITLE
Added Node.js requirement to setup guide

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -2,7 +2,7 @@
 This project attemps to match Visual Studio Code's Debugger fairly closely so their documentation can be pretty helpful. See [https://code.visualstudio.com/docs/editor/debugging](https://code.visualstudio.com/docs/editor/debugging)
 
 ## Requirements
-This plugin requires Node.js installed.
+This plugin requires that Node.js is installed.
 
 ## Setting up your debugger
 - Opening the debug panel

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,6 +1,9 @@
 # Getting Started Guide
 This project attemps to match Visual Studio Code's Debugger fairly closely so their documentation can be pretty helpful. See [https://code.visualstudio.com/docs/editor/debugging](https://code.visualstudio.com/docs/editor/debugging)
 
+## Requirements
+This plugin requires Node.js installed.
+
 ## Setting up your debugger
 - Opening the debug panel
   - from the command palette `Debugger: Open`


### PR DESCRIPTION
Node.js needs to be installed for the plugin to work and I couldn't find it anywhere in the readme or the setup guide. I spent more than 1 hour trying to figure out until I found #32 which put me on the right track.

If you accept the pull request, newcomers will have an easier time getting the plugin started. 

PS. Thank You for creating the plugin in the first place!