### PR TITLE
Add experimental socket attach support and some debugpy related changes

### DIFF
--- a/debugger.sublime-settings
+++ b/debugger.sublime-settings
@@ -38,9 +38,5 @@
 
 	// sets a specific path for node if not set adapters that require node to run will use whatever is in your path
 	"node": null,
-
-	"python.node": null, // python adapter only runs on node <= v12.5.0 so you can set a specific version
-	"python.experimental_debugpy_adapter": false,
-	"python.experimental_socket_attach": false,
 }
 

--- a/debugger.sublime-settings
+++ b/debugger.sublime-settings
@@ -1,5 +1,5 @@
-{	
-	// Open the debugger automatically when a project that is set up for debugging has been opened 
+{
+	// Open the debugger automatically when a project that is set up for debugging has been opened
 	// In otherwords it has configurations in the .sublime-project defined
 	// "settings" : {
 	//	"debug.configurations" : [...]
@@ -38,8 +38,9 @@
 
 	// sets a specific path for node if not set adapters that require node to run will use whatever is in your path
 	"node": null,
-	
+
 	"python.node": null, // python adapter only runs on node <= v12.5.0 so you can set a specific version
 	"python.experimental_debugpy_adapter": false,
+	"python.experimental_socket_attach": false,
 }
 

--- a/examples/python/python.sublime-project
+++ b/examples/python/python.sublime-project
@@ -14,9 +14,9 @@
 				"type": "python",
 				"request": "launch",
 				"program": "${project_path}/main.py",
-				"debugOptions" : {
-					"RedirectOutput": true,
-				}
+				"debugOptions" : [
+					"RedirectOutput"
+				]
 			},
 		]
 	}

--- a/modules/dap/types.py
+++ b/modules/dap/types.py
@@ -25,7 +25,7 @@ def json_from_array(into_json: Callable[[__T], dict], array: List[__T]) -> list:
 	return json
 
 class Default(dict):
-    def __missing__(self, key): 
+    def __missing__(self, key):
         return key.join("{}")
 
 class Error(core.Error):
@@ -153,7 +153,7 @@ class Source:
 	def __init__(self, name: Optional[str], path: Optional[str], sourceReference: int, presentationHint: int, origin: Optional[str], sources: List['Source']) -> None:
 		# no idea how there are supposed to be uniquely identified but there is an event LoadedSourceEvent that seems to assume they are
 		self.id = f'{name}~{path}~{sourceReference}'
-		
+
 		self.name = name or path
 		self.path = path
 		self.sourceReference = sourceReference
@@ -170,7 +170,7 @@ class Source:
 				hint = Source.emphasize
 			elif json_hint == 'deemphasize':
 				hint = Source.deemphasize
-		
+
 		sources = array_from_json(Source.from_json, json.get('sources', []))
 
 		return Source(
@@ -224,7 +224,7 @@ class Capabilities:
 		self.supportsExceptionOptions = json.get('supportsExceptionOptions', False)
 		self.supportsValueFormattingOptions = json.get('supportsValueFormattingOptions', False)
 		self.supportsExceptionInfoRequest = json.get('supportsExceptionInfoRequest', False)
-		self.supportTerminateDebuggee = json.get('supportTerminateDebuggee', False)
+		self.supportsTerminateDebuggee = json.get('supportsTerminateDebuggee', False)
 		self.supportsDelayedStackTraceLoading = json.get('supportsDelayedStackTraceLoading', False)
 		self.supportsLoadedSourcesRequest = json.get('supportsLoadedSourcesRequest', False)
 		self.supportsLogPoints = json.get('supportsLogPoints', False)
@@ -252,7 +252,7 @@ class ThreadEvent:
 	@staticmethod
 	def from_json(json) -> ThreadEvent:
 		return ThreadEvent(
-			threadId=json['threadId'], 
+			threadId=json['threadId'],
 			reason=json['reason'],
 		)
 
@@ -454,9 +454,9 @@ class BreakpointResult:
 	@staticmethod
 	def from_json(json: dict) -> 'BreakpointResult':
 		return BreakpointResult(
-			json['verified'], 
-			json.get('line'), 
-			json.get('column'), 
+			json['verified'],
+			json.get('line'),
+			json.get('column'),
 			json.get('message'),
 			json.get('id'))
 
@@ -507,7 +507,7 @@ class ModuleEvent:
 	new = 1
 	changed = 2
 	removed = 3
-	
+
 	reasons = {'new': new, 'changed': changed, 'removed': removed}
 
 	def __init__(self, json: dict):
@@ -519,7 +519,7 @@ class LoadedSourceEvent:
 	new = 1
 	changed = 2
 	removed = 3
-	
+
 	reasons = {'new': new, 'changed': changed, 'removed': removed}
 
 	def __init__(self, json: dict):

--- a/modules/debugger/adapter/__init__.py
+++ b/modules/debugger/adapter/__init__.py
@@ -2,5 +2,5 @@ from .adapter import Adapter, Adapters
 from .configuration import Configuration, ConfigurationExpanded, ConfigurationCompound
 from .transports import CommandSocketTransport, SocketTransport, StdioTransport
 from . import vscode
-from .dependencies import get_and_warn_require_node, get_and_warn_require_node_less_than_or_equal
+from .dependencies import get_and_warn_require_node
 from ..adapters import *

--- a/modules/debugger/adapter/__init__.py
+++ b/modules/debugger/adapter/__init__.py
@@ -1,6 +1,6 @@
 from .adapter import Adapter, Adapters
 from .configuration import Configuration, ConfigurationExpanded, ConfigurationCompound
-from .transports import StdioTransport, SocketTransport
+from .transports import CommandSocketTransport, SocketTransport, StdioTransport
 from . import vscode
 from .dependencies import get_and_warn_require_node, get_and_warn_require_node_less_than_or_equal
 from ..adapters import *

--- a/modules/debugger/adapter/adapter.py
+++ b/modules/debugger/adapter/adapter.py
@@ -10,7 +10,7 @@ import json
 class Adapter (Protocol):
 	@property
 	def type(self): ...
-	async def start(self, log: core.Logger): ...
+	async def start(self, log: core.Logger, configuration: ConfigurationExpanded): ...
 
 	@property
 	def version(self) -> Optional[str]: ...
@@ -114,7 +114,7 @@ class Adapters:
 					core.run(Adapters._insert_snippet(sublime.active_window(), insert))
 
 				snippet_input_items.append(ui.InputListItem(insert, snippet.get('label', 'label')))
-			
+
 			if not snippet_input_items:
 				snippet_input_items.append(ui.InputListItem(lambda: insert_custom(adapter.type, "launch"), 'launch'))
 				snippet_input_items.append(ui.InputListItem(lambda: insert_custom(adapter.type, "attach"), 'attach'))

--- a/modules/debugger/adapter/dependencies.py
+++ b/modules/debugger/adapter/dependencies.py
@@ -21,21 +21,9 @@ def get_node_path(adapter_type: str):
 
 def get_and_warn_require_node(adapter_type: str, log: core.Logger):
 	node_path = get_node_path(adapter_type)
-	try: 
+	try:
 		subprocess.check_output([node_path, '-v'])
 	except Exception as e:
 		log.error(f'This adapter requires node it looks like you may not have node installed or it is not on your path: {e}. \nhttps://nodejs.org/')
-
-	return node_path
-
-def get_and_warn_require_node_less_than_or_equal(adapter_type: str, log: core.Logger, max_version: str):
-	node_path = get_node_path(adapter_type)
-	try: 
-		version = subprocess.check_output([node_path, '-v']).strip().decode("utf-8")
-		if version_tuple(version) > version_tuple(max_version):
-			log.error(f'This adapter may not run on your version of node. It may require a version less than or equal to {max_version}. The version of node found is {version} If you want this issue fixed you can file an issue to the adapter owner.')
-
-	except Exception as e:
-		log.error(f'This adapter requires node it looks like you may not have node installed or it is not on your path: {e}\nhttps://nodejs.org/')
 
 	return node_path

--- a/modules/debugger/adapters/chrome.py
+++ b/modules/debugger/adapters/chrome.py
@@ -3,10 +3,10 @@ from ..import adapter
 
 class Chrome(adapter.Adapter):
 	@property
-	def type(self): 
+	def type(self):
 		return 'chrome'
 
-	async def start(self, log):
+	async def start(self, log, configuration):
 		node = adapter.get_and_warn_require_node(self.type, log)
 
 		install_path = adapter.vscode.install_path(self.type)
@@ -19,16 +19,16 @@ class Chrome(adapter.Adapter):
 	async def install(self, log):
 		url = 'https://marketplace.visualstudio.com/_apis/public/gallery/publishers/msjsdiag/vsextensions/debugger-for-chrome/latest/vspackage'
 		await adapter.vscode.install(self.type, url, log)
-		
+
 	@property
-	def installed_version(self) -> Optional[str]: 
+	def installed_version(self) -> Optional[str]:
 		return adapter.vscode.installed_version(self.type)
 
 	@property
-	def configuration_snippets(self) -> list: 
+	def configuration_snippets(self) -> list:
 		return adapter.vscode.configuration_snippets(self.type)
 
 	@property
-	def configuration_schema(self) -> dict: 
+	def configuration_schema(self) -> dict:
 		return adapter.vscode.configuration_schema(self.type)
 

--- a/modules/debugger/adapters/firefox.py
+++ b/modules/debugger/adapters/firefox.py
@@ -3,10 +3,10 @@ from ..import adapter
 
 class Firefox(adapter.Adapter):
 	@property
-	def type(self): 
+	def type(self):
 		return 'firefox'
 
-	async def start(self, log):
+	async def start(self, log, configuration):
 		node = adapter.get_and_warn_require_node(self.type, log)
 		install_path = adapter.vscode.install_path(self.type)
 		command = [
@@ -18,15 +18,15 @@ class Firefox(adapter.Adapter):
 	async def install(self, log):
 		url = 'https://marketplace.visualstudio.com/_apis/public/gallery/publishers/firefox-devtools/vsextensions/vscode-firefox-debug/latest/vspackage'
 		await adapter.vscode.install(self.type, url, log)
-	
+
 	@property
-	def installed_version(self) -> Optional[str]: 
+	def installed_version(self) -> Optional[str]:
 		return adapter.vscode.installed_version(self.type)
 
 	@property
-	def configuration_snippets(self) -> list: 
+	def configuration_snippets(self) -> list:
 		return adapter.vscode.configuration_snippets(self.type)
 
 	@property
-	def configuration_schema(self) -> dict: 
+	def configuration_schema(self) -> dict:
 		return adapter.vscode.configuration_schema(self.type)

--- a/modules/debugger/adapters/gdb.py
+++ b/modules/debugger/adapters/gdb.py
@@ -3,10 +3,10 @@ from ..import adapter
 
 class GDB(adapter.Adapter):
 	@property
-	def type(self): 
+	def type(self):
 		return "gdb"
 
-	async def start(self, log):
+	async def start(self, log, configuration):
 		node = adapter.get_and_warn_require_node(self.type, log)
 		install_path = adapter.vscode.install_path(self.type)
 		command = [
@@ -20,13 +20,13 @@ class GDB(adapter.Adapter):
 		await adapter.vscode.install(self.type, url, log)
 
 	@property
-	def installed_version(self) -> Optional[str]: 
+	def installed_version(self) -> Optional[str]:
 		return adapter.vscode.installed_version(self.type)
 
 	@property
-	def configuration_snippets(self) -> list: 
+	def configuration_snippets(self) -> list:
 		return adapter.vscode.configuration_snippets(self.type)
 
 	@property
-	def configuration_schema(self) -> dict: 
+	def configuration_schema(self) -> dict:
 		return adapter.vscode.configuration_schema(self.type)

--- a/modules/debugger/adapters/go.py
+++ b/modules/debugger/adapters/go.py
@@ -7,10 +7,10 @@ import shutil
 
 class Go(adapter.Adapter):
 	@property
-	def type(self): 
+	def type(self):
 		return "go"
 
-	async def start(self, log):
+	async def start(self, log, configuration):
 		node = adapter.get_and_warn_require_node(self.type, log)
 		install_path = adapter.vscode.install_path(self.type)
 		command = [
@@ -33,13 +33,13 @@ class Go(adapter.Adapter):
 		return configuration
 
 	@property
-	def installed_version(self) -> Optional[str]: 
+	def installed_version(self) -> Optional[str]:
 		return adapter.vscode.installed_version(self.type)
 
 	@property
-	def configuration_snippets(self) -> list: 
+	def configuration_snippets(self) -> list:
 		return adapter.vscode.configuration_snippets(self.type)
 
 	@property
-	def configuration_schema(self) -> dict: 
+	def configuration_schema(self) -> dict:
 		return adapter.vscode.configuration_schema(self.type)

--- a/modules/debugger/adapters/lldb.py
+++ b/modules/debugger/adapters/lldb.py
@@ -1,16 +1,16 @@
 from ...typecheck import *
 from ..import adapter
 from ...import core
-from ..adapter.transports import SocketTransport
+from ..adapter.transports import CommandSocketTransport
 from ..util import get_debugger_setting
 
 import subprocess
 class LLDB(adapter.Adapter):
 	@property
-	def type(self): 
+	def type(self):
 		return "lldb"
 
-	async def start(self, log: core.Logger):
+	async def start(self, log: core.Logger, configuration):
 		install_path = adapter.vscode.install_path(self.type)
 
 		codelldb = f'{install_path}/extension/adapter2/codelldb'
@@ -19,7 +19,7 @@ class LLDB(adapter.Adapter):
 			codelldb,
 			"--libpython", libpython
 		]
-		return SocketTransport(log, command)
+		return CommandSocketTransport(log, command)
 
 	async def install(self, log: core.Logger):
 		if core.platform.windows:
@@ -32,13 +32,13 @@ class LLDB(adapter.Adapter):
 		await adapter.vscode.install(self.type, url, log)
 
 	@property
-	def installed_version(self) -> Optional[str]: 
+	def installed_version(self) -> Optional[str]:
 		return adapter.vscode.installed_version(self.type)
 
 	@property
-	def configuration_snippets(self) -> list: 
+	def configuration_snippets(self) -> list:
 		return adapter.vscode.configuration_snippets(self.type)
 
 	@property
-	def configuration_schema(self) -> dict: 
+	def configuration_schema(self) -> dict:
 		return adapter.vscode.configuration_schema(self.type)

--- a/modules/debugger/adapters/node.py
+++ b/modules/debugger/adapters/node.py
@@ -9,7 +9,7 @@ class Node(adapter.Adapter):
 	@property
 	def info(self): return adapter.vscode.info(self.type)
 
-	async def start(self, log):
+	async def start(self, log, configuration):
 		node = adapter.get_and_warn_require_node(self.type, log)
 		install_path = adapter.vscode.install_path(self.type)
 		command = [
@@ -21,15 +21,15 @@ class Node(adapter.Adapter):
 	async def install(self, log):
 		url = 'https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-vscode/vsextensions/node-debug2/latest/vspackage'
 		await adapter.vscode.install(self.type, url, log)
-		
+
 	@property
-	def installed_version(self) -> Optional[str]: 
+	def installed_version(self) -> Optional[str]:
 		return adapter.vscode.installed_version(self.type)
 
 	@property
-	def configuration_snippets(self) -> list: 
+	def configuration_snippets(self) -> list:
 		return adapter.vscode.configuration_snippets(self.type)
 
 	@property
-	def configuration_schema(self) -> dict: 
+	def configuration_schema(self) -> dict:
 		return adapter.vscode.configuration_schema(self.type)

--- a/modules/debugger/adapters/php.py
+++ b/modules/debugger/adapters/php.py
@@ -21,10 +21,10 @@ import re
 
 class PHP(adapter.Adapter):
 	@property
-	def type(self): 
+	def type(self):
 		return 'php'
 
-	async def start(self, log):
+	async def start(self, log, configuration):
 		node = adapter.get_and_warn_require_node(self.type, log)
 
 		install_path = adapter.vscode.install_path(self.type)
@@ -37,22 +37,22 @@ class PHP(adapter.Adapter):
 	async def install(self, log):
 		url = 'https://marketplace.visualstudio.com/_apis/public/gallery/publishers/felixfbecker/vsextensions/php-debug/latest/vspackage'
 		await adapter.vscode.install(self.type, url, log)
-		
+
 	@property
-	def installed_version(self) -> Optional[str]: 
+	def installed_version(self) -> Optional[str]:
 		return adapter.vscode.installed_version(self.type)
 
 	@property
-	def configuration_snippets(self) -> list: 
+	def configuration_snippets(self) -> list:
 		return adapter.vscode.configuration_snippets(self.type)
 
 	@property
-	def configuration_schema(self) -> dict: 
+	def configuration_schema(self) -> dict:
 		return adapter.vscode.configuration_schema(self.type)
 
 	def on_hover_provider(self, view, point):
 		seperators = "./\\()\"'-:,.;<>~!@#%^&*|+=[]{}`~?."
-		word = view.expand_by_class(point, sublime.CLASS_WORD_START | sublime.CLASS_WORD_END, separators=seperators)		
+		word = view.expand_by_class(point, sublime.CLASS_WORD_START | sublime.CLASS_WORD_END, separators=seperators)
 		word_string = word and view.substr(word)
 		if not word_string:
 			return None
@@ -60,6 +60,6 @@ class PHP(adapter.Adapter):
 		match = re.search("\\$[a-zA-Z0-9_]*", word_string)
 		if not match:
 			return None
-			
+
 		word_string = match.group()
 		return (match.group(), word)

--- a/modules/debugger/adapters/python.py
+++ b/modules/debugger/adapters/python.py
@@ -7,14 +7,32 @@ class Python(adapter.Adapter):
 	@property
 	def type(self): return 'python'
 
-	async def start(self, log):
+	async def start(self, log, configuration):
 		use_debugpy = get_debugger_setting('python.experimental_debugpy_adapter', False)
+		use_socket = get_debugger_setting('python.experimental_socket_attach', False)
+
+		if use_socket and configuration.request == "attach":
+			host = configuration.get("host")
+			port = configuration.get("port")
+
+			if not host and not port:
+				connect = configuration.get("connect") or {}
+				host = connect.get("host")
+				port = connect.get("port")
+
+			if not host or not port:
+				sublime.error_message("Warning: Check your debugger configuration.\n\nFields `host` and `port` in configuration is empty. If it contained a $variable that variable may not have existed.""")
+
+			return adapter.SocketTransport(log, host, port)
+
 		install_path = adapter.vscode.install_path(self.type)
 
 		if use_debugpy:
+			python = configuration.get("pythonPath", "python")
+
 			command = [
-				'python3', # probably doesn't work cross platform?
-				f'{install_path}/extension/pythonFiles/lib/python/debugpy/wheels/debugpy/adapter',
+				python, # probably doesn't work cross platform?
+				f'{install_path}/extension/pythonFiles/lib/python/debugpy/adapter',
 			]
 			log.info("Using experimental debugpy adapter")
 		else:
@@ -29,17 +47,17 @@ class Python(adapter.Adapter):
 	async def install(self, log):
 		url = 'https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-python/vsextensions/python/latest/vspackage'
 		await adapter.vscode.install(self.type, url, log)
-		
+
 	@property
-	def installed_version(self) -> Optional[str]: 
+	def installed_version(self) -> Optional[str]:
 		return adapter.vscode.installed_version(self.type)
 
 	@property
-	def configuration_snippets(self) -> list: 
+	def configuration_snippets(self) -> list:
 		return adapter.vscode.configuration_snippets(self.type)
 
 	@property
-	def configuration_schema(self) -> dict: 
+	def configuration_schema(self) -> dict:
 		return adapter.vscode.configuration_schema(self.type)
 
 	# TODO: patch in env since python seems to not inherit it from the adapter proccess.
@@ -47,5 +65,5 @@ class Python(adapter.Adapter):
 		if configuration.request == "launch":
 			if not configuration.get("program"):
 				sublime.error_message("Warning: Check your debugger configuration.\n\nField `program` in configuration is empty. If it contained a $variable that variable may not have existed.""")
-		
+
 		return configuration

--- a/modules/debugger/debugger_session.py
+++ b/modules/debugger/debugger_session.py
@@ -4,7 +4,7 @@ from ..typecheck import *
 from ..import core, dap
 
 from .terminals import (
-	Terminal, 
+	Terminal,
 	TerminalCommand,
 )
 from .adapter import (
@@ -28,7 +28,7 @@ class DebuggerSession(dap.ClientEventsListener, core.Logger):
 	running = 2
 
 	starting = 3
-	stopping = 4	
+	stopping = 4
 
 	stopped_reason_build_failed=0
 	stopped_reason_launch_error=1
@@ -172,7 +172,7 @@ class DebuggerSession(dap.ClientEventsListener, core.Logger):
 
 		self._change_status("Starting")
 		try:
-			transport = await adapter_configuration.start(log=self)
+			transport = await adapter_configuration.start(log=self, configuration=self.configuration)
 		except Exception as e:
 			raise core.Error(f"Unable to start the adapter process: {e}")
 
@@ -204,7 +204,7 @@ class DebuggerSession(dap.ClientEventsListener, core.Logger):
 				self.error("there was an error in configuration done {}".format(e))
 		core.run(Initialized())
 
-		
+
 
 		self.capabilities = await adapter.Initialize()
 		# remove/add any exception breakpoint filters
@@ -385,7 +385,7 @@ class DebuggerSession(dap.ClientEventsListener, core.Logger):
 		else:
 			await self.client.Disconnect()
 
-		
+
 	def clear_session(self):
 		if self.launching_async:
 			self.launching_async.cancel()
@@ -401,7 +401,7 @@ class DebuggerSession(dap.ClientEventsListener, core.Logger):
 			self.adapter.dispose()
 			self.adapter = None
 
-			
+
 	async def stop_forced(self, reason) -> None:
 		if self.state == DebuggerSession.stopping or self.state == DebuggerSession.stopped:
 			return
@@ -477,7 +477,7 @@ class DebuggerSession(dap.ClientEventsListener, core.Logger):
 		scopes = await self.client.GetScopes(frame)
 		self.variables = [Variable(self, ScopeReference(scope)) for scope in scopes]
 		self.on_updated_variables()
-		
+
 	def on_breakpoint_event(self, event: dap.BreakpointEvent):
 		b = self.breakpoints_for_id.get(event.result.id)
 		if b:


### PR DESCRIPTION
These changes add experimental socket attach support for remote debugging `Python` applications via `attach`. I tried to follow the existing experimental option pattern to not impose this a requirement.

The biggest change is to `SocketTransport` being split into two classes to allow for both command and host/port support.

There are also some `debugpy` related changes to match the latest version of the adapter from `vscode`.