### PR TITLE
Fix: Update Go extension URL

### DIFF
--- a/modules/debugger/adapters/go.py
+++ b/modules/debugger/adapters/go.py
@@ -20,7 +20,7 @@ class Go(adapter.Adapter):
 		return adapter.StdioTransport(log, command)
 
 	async def install(self, log):
-		url = 'https://marketplace.visualstudio.com/_apis/public/gallery/publishers/ms-vscode/vsextensions/Go/latest/vspackage'
+		url = 'https://marketplace.visualstudio.com/_apis/public/gallery/publishers/golang/vsextensions/Go/latest/vspackage'
 		await adapter.vscode.install(self.type, url, log)
 
 	# Patch in dlvToolPath to point to dlv if present in settings or path


### PR DESCRIPTION
The Go extension URL used to install the Go adapter has been changed due to a change in extension ownership, from Microsoft to the official Go team.