### PR TITLE
Support for ST3 DAP plugins, and custom configuration formatting

### DIFF
--- a/modules/debugger/adapter/install.py
+++ b/modules/debugger/adapter/install.py
@@ -30,6 +30,17 @@ class AdapterInstalledInformation:
 		self.snippets = snippets
 
 
+class SublimeAdapterInstall:
+
+	@staticmethod
+	def from_json(path: str) -> dict:
+		
+		with open(path, 'r') as f:
+			info = json.load(f)
+		
+		return info
+
+
 class VSCodeAdapterInstall:
 	def __init__(self, name: str, url: str) -> None:
 		self.name = name


### PR DESCRIPTION
Hey! I'm with Blur Studio and we made SublimeLinter-style plugins ([a template](https://github.com/blurstudio/sublime_debugger-plugin) and [a Maya adapter](https://github.com/blurstudio/sublime_debugger-maya)) for your debugger, thanks to the custom adapters section of your settings. However, for the configurations to appear in the "select configuration" menu, we implemented the following changes.

Alongside these changes is also functionality for formatting the selected configuration based on values given in the debugger settings, that way the user only has to modify values in Debugger > Settings instead of going into their project settings to find the configurations.