### PR TITLE
Add Elixir support

### DIFF
--- a/examples/elixir/elixir.sublime-project
+++ b/examples/elixir/elixir.sublime-project
@@ -1,0 +1,30 @@
+{
+	"folders": [
+		{
+			"path": ".",
+		},
+	],
+	"debugger_configurations": [
+		{
+			"type": "elixir",
+			"name": "mix (Default task)",
+			"request": "launch",
+			"projectDir": "${project_path}"
+		},
+		{
+			"type": "elixir",
+			"name": "mix test",
+			"request": "launch",
+			"task": "test",
+			"taskArgs": [
+				"--trace"
+			],
+			"startApps": true,
+			"projectDir": "${project_path}",
+			"requireFiles": [
+				"test/**/test_helper.exs",
+				"test/**/*_test.exs"
+			]
+		}
+	],
+}

--- a/examples/elixir/lib/test_app.ex
+++ b/examples/elixir/lib/test_app.ex
@@ -1,0 +1,9 @@
+defmodule TestApp do
+  use Application
+
+  def start(_type, _args) do
+    IO.puts("starting")
+
+    Task.start(fn -> IO.puts("task") end)
+  end
+end

--- a/examples/elixir/mix.exs
+++ b/examples/elixir/mix.exs
@@ -1,0 +1,16 @@
+defmodule TestApp.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :test_app,
+      version: "0.0.0"
+    ]
+  end
+
+  def application do
+    [
+      mod: {TestApp, []}
+    ]
+  end
+end

--- a/modules/adapters/__init__.py
+++ b/modules/adapters/__init__.py
@@ -7,6 +7,7 @@ from .go import Go
 from .php import PHP
 from .python import Python
 from .ruby import Ruby
+from .elixir import Elixir
 
 from .node import Node
 from .chrome import Chrome

--- a/modules/adapters/elixir.py
+++ b/modules/adapters/elixir.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+from ..typecheck import *
+
+from .import adapter
+from .. import dap
+from .. import core
+
+import shutil
+
+class Elixir(adapter.AdapterConfiguration):
+
+	type = "elixir"
+	docs = "https://github.com/elixir-lsp/elixir-ls#debugger-support"
+
+	async def start(self, log: core.Logger, configuration: dap.ConfigurationExpanded):
+
+		install_path = adapter.vscode.install_path(self.type)
+		extension = 'bat' if core.platform.windows else 'sh'
+		command = [
+			f'{install_path}/extension/elixir-ls-release/debugger.{extension}'
+		]
+		return adapter.StdioTransport(log, command)
+
+	async def install(self, log: core.Logger):
+
+		url = await adapter.openvsx.latest_release_vsix("elixir-lsp", "elixir-ls")
+		await adapter.vscode.install(self.type, url, log)
+
+	@property
+	def installed_version(self):
+		return adapter.vscode.installed_version(self.type)
+
+	@property
+	def configuration_snippets(self):
+		return adapter.vscode.configuration_snippets(self.type)
+
+	@property
+	def configuration_schema(self):
+		return adapter.vscode.configuration_schema(self.type)
+
+


### PR DESCRIPTION
This PR adds Elixir support

The implementation is based on https://github.com/elixir-lsp/vscode-elixir-ls which adds some wrappers on top of https://github.com/elixir-lsp/elixir-ls

The VSCode implementation exposes `mix_task` name(because it relies on the `mix` tool) but I decided to go with the `elixir` name.
It might be a bit confusing(I can add a note in the README regarding that) but at the same time, it kind of makes the naming more consistent. 
But I am happy to change it to `mix_task`