### PR TITLE
Java: Enable LSP support in generated view

### DIFF
--- a/modules/adapters/java.py
+++ b/modules/adapters/java.py
@@ -1,4 +1,4 @@
-from ..typecheck import Optional, Dict, Any, Tuple
+from ..typecheck import Optional, Dict, Any, Tuple, List
 from ..import core
 from ..import dap
 from .import util
@@ -51,11 +51,11 @@ class Java(dap.AdapterConfiguration):
 
 		return dap.SocketTransport(log, 'localhost', port)
 
-	async def on_navigate_to_source(self, source: dap.SourceLocation) -> Optional[Tuple[str, str]]:
+	async def on_navigate_to_source(self, source: dap.SourceLocation) -> Optional[Tuple[str, str, List[Tuple[str, Any]]]]:
 		if not source.source.path or not source.source.path.startswith('jdt:'):
 			return None
 		content = await self.get_class_content_for_uri(source.source.path)
-		return content, 'text/java'
+		return content, 'text/java', [("lsp_uri", source.source.path)]
 
 	async def get_class_content_for_uri(self, uri):
 		return await self.lsp_request('java/classFileContents', {'uri': uri})

--- a/modules/dap/configuration.py
+++ b/modules/dap/configuration.py
@@ -96,10 +96,10 @@ class AdapterConfiguration:
 	def ui(self, debugger: Debugger) -> Any|None:
 		...
 
-	async def on_navigate_to_source(self, source: dap.SourceLocation) -> Optional[Tuple[str, str]]:
+	async def on_navigate_to_source(self, source: dap.SourceLocation) -> Optional[Tuple[str, str, List[Tuple[str, Any]]]]:
 		"""
 		Allows the adapter to supply content when navigating to source.
-		Returns: None to keep the default behavior, else a tuple (content, mime_type)
+		Returns: None to keep the default behavior, else a tuple (content, mime_type, custom_view_settings)
 		"""
 		return None
 

--- a/modules/source_navigation.py
+++ b/modules/source_navigation.py
@@ -115,12 +115,13 @@ class SourceNavigationProvider:
 
 		if adapter_content or source.source.sourceReference:
 			if adapter_content:
-				content, mime_type = adapter_content
+				content, mime_type, custom_settings = adapter_content
 			else:
 				session = self.debugger.session
 				if not session:
 					raise core.Error('No Active Debug Session')
 				content, mime_type = await session.get_source(source.source)
+				custom_settings = []
 
 			# the generated view was closed (no buffer) throw it away
 			if self.generated_view and not self.generated_view.buffer_id():
@@ -131,6 +132,7 @@ class SourceNavigationProvider:
 			self.generated_view = view
 			view.set_name(source.source.name or "")
 			view.set_read_only(False)
+			view.settings().update(custom_settings)
 
 			syntax = syntax_name_for_mime_type.get(mime_type, 'text.plain')
 			view.assign_syntax(sublime.find_syntax_by_scope(syntax)[0])


### PR DESCRIPTION
Currently, JDTLS is not active on a generated view.

If I enable JDTLS for buffers by adding `buffer` to the schemes in the LSP-jdtls settings, it does not work correctly. However, setting `lsp_uri` to the `jdt://` path fixes this issue.

@rwols Setting `lsp_uri` is an LSP internal thing and not documented as far as I know?
