### PR TITLE
Fixing depends_on_sequence

### DIFF
--- a/modules/output_panel_terminus.py
+++ b/modules/output_panel_terminus.py
@@ -40,7 +40,7 @@ class TerminusOutputPanel(OutputPanel):
 			arguments = task.copy()
 
 			# if we don't remove these additional arguments Default.exec.ExecCommand will be unhappy
-			for key in ['name', 'background', 'start_file_regex', 'end_file_regex', 'depends_on', 'depends_on_order']:
+			for key in ['name', 'background', 'start_file_regex', 'end_file_regex', 'depends_on', 'depends_on_sequence']:
 				if key in arguments:
 					del arguments[key]
 


### PR DESCRIPTION
We need to remove 'depends_on_sequence' from arguments which go to terminus, because this is the actual name from the dictionary which we use. If we will not remove it terminus will cancel it job on the start