### PR TITLE
go: support remote debugging when "port" is present in configuration

### DIFF
--- a/modules/adapters/go.py
+++ b/modules/adapters/go.py
@@ -17,12 +17,19 @@ class Go(dap.Adapter):
 	go_dlv = Setting['str|None'](key='go_dlv', default=None, description='Sets a specific path for dlv if not set go will use whatever is in your path')
 
 	async def start(self, console: dap.Console, configuration: dap.ConfigurationExpanded):
-		port = util.get_open_port()
-		dlv = self.go_dlv or shutil.which('dlv')
-		if not dlv:
-			raise dap.Error('`dlv` not found see https://github.com/go-delve/delve for setting up delve')
+		if configuration.get('port'):
+			host = configuration.get('host', 'localhost')
+			port = configuration['port']
+			command = None
+			console.info(f'Start remote debugging, connecting {host}:{port}')
+		else:
+			host = 'localhost'
+			port = util.get_open_port()
+			dlv = self.go_dlv or shutil.which('dlv')
+			if not dlv:
+				raise dap.Error('`dlv` not found see https://github.com/go-delve/delve for setting up delve')
 
-		command = [dlv, 'dap', '--listen', f'localhost:{port}']
+			command = [dlv, 'dap', '--listen', f'{host}:{port}']
 
 		cwd = configuration.get('cwd')
 
@@ -41,6 +48,7 @@ class Go(dap.Adapter):
 			console.log('stderr', data)
 
 		return dap.SocketTransport(
+			host=host,
 			port=port,
 			command=command,
 			cwd=cwd,


### PR DESCRIPTION
### Description
This change is to support remote debugging for golang. Currently it's not supported because the adapter doesn't read "port" attribute in the configuration at all.

### Test result
Here's my configuration:
<details>
<summary>sample config in "mygo.sublime-project"</summary>

```json

{
  "debugger_configurations": [
    {
      "name": "go debug (remote launch)",
      "type": "go",
      "request": "launch",
      "mode": "debug",
      "host": "127.0.0.1",
      "port": 2345,
      "program": "/tmp/zhaojr/mygo/main.go",
      "substitutePath": [
        {
          "from": "/Volumes/ramdisk/w/mygo",
          "to": "/tmp/zhaojr/mygo"
        }
      ]
    },
    {
      "name": "go debug (remote attach)",
      "type": "go",
      "request": "attach",
      "mode": "remote",
      "host": "127.0.0.1",
      "port": 2345,
      "substitutePath": [
        {
          "from": "/Volumes/ramdisk/w/mygo",
          "to": "/tmp/zhaojr/mygo"
        }
      ]
    }
  ]
}
```
</details>

It defines two ways for remote debugging:
- "remote launch": first run `dlv dap --listen :2345` on remote machine, and `dlv` will compile the executable on it automatically when Debugger connects to it;
- "remote attach": first compile the executable on remote machine, and then run `dlv exec ./executable --headless --listen :2345` on it waiting for Debugger to attach to;

You can check [VS Code doc](https://github.com/golang/vscode-go/blob/master/docs/debugging.md) for more details.

We use SSH tunnel to forward remote port to local machine:
```sh
ssh -N -L 127.0.0.1:2345:127.0.0.1:2345 remote_host
```

See the screenshots for test details:
<img width="2032" height="1162" alt="01-remote-launch" src="https://github.com/user-attachments/assets/e13f8626-e255-44fc-82cf-2c1f5d3f4dcb" />
<img width="2032" height="1162" alt="02-remote-attach" src="https://github.com/user-attachments/assets/9e96f816-0113-4b67-8c58-67be7ca85c92" />
